### PR TITLE
adding addresses for 3.11.0-88-mptcp

### DIFF
--- a/addresses
+++ b/addresses
@@ -15,3 +15,11 @@ PTMX_FOPS           0xffffffff81b1ba60LL
 TTY_RELEASE         0xffffffff8134f990LL
 COMMIT_CREDS        0xffffffff8108b420LL
 PREPARE_KERNEL_CRED 0xffffffff8108b710LL
+
+
+Ubuntu - 3.11.0-88-mptcp
+------------------------
+PTMX_FOPS           0xffffffff81eeeac0LL
+TTY_RELEASE         0xffffffff813c0560LL
+COMMIT_CREDS        0xffffffff8107a330LL
+PREPARE_KERNEL_CRED 0xffffffff8107a600LL


### PR DESCRIPTION
These are the addresses for 3.11.0-88-mptcp on Ubuntu 13.10.
Kernel installed from : http://multipath-tcp.org/pmwiki.php/Users/AptRepository
