### PR TITLE
Add addresses for Ubuntu with kernel 3.8.0-29-generic

### DIFF
--- a/addresses
+++ b/addresses
@@ -39,3 +39,10 @@ PTMX_FOPS           0xffffffff81f13f60LL
 TTY_RELEASE         0xffffffff81411f90LL
 COMMIT_CREDS        0xffffffff81084800LL
 PREPARE_KERNEL_CRED 0xffffffff81084ac0LL
+
+Ubuntu - 3.8.0-29-generic (Ubuntu Server 12.04.3)
+-------------------------
+PTMX_FOPS           0xffffffff81f16f20LL
+TTY_RELEASE         0xffffffff81420c30LL
+COMMIT_CREDS        0xffffffff81086780LL
+PREPARE_KERNEL_CRED 0xffffffff81086a00LL


### PR DESCRIPTION
It's the default package installed with Ubuntu 12.04.3 Server.
